### PR TITLE
Enumerate firewall rules Linux module

### DIFF
--- a/changelog
+++ b/changelog
@@ -35,7 +35,7 @@
 
 -Listeners:
     added http
-    added http_foreign (for 'foreign' Emire listeners)
+    added http_foreign (for 'foreign' Empire listeners)
     added meterpreter (for meterpreter/cobalt strike, using Invoke-Shellcode)
     added management/switch_listener module which switches an agent to a new listener module comms
     redid hop listeners, added listeners/http_hop

--- a/lib/modules/python/collection/linux/enum_firewall.py
+++ b/lib/modules/python/collection/linux/enum_firewall.py
@@ -1,0 +1,75 @@
+from lib.common import helpers
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Linux Hashdump',
+
+            # list of one or more authors for the module
+            'Author': ['@harmj0y'],
+
+            # more verbose multi-line description of the module
+            'Description': ("Extracts the /etc/passwd and /etc/shadow, unshadowing the result."),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : True,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': []
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+
+        script = """
+from subprocess import check_output
+out = check_output(["iptables","-S"])
+print out
+"""
+
+        return script

--- a/lib/modules/python/collection/linux/enum_firewall.py
+++ b/lib/modules/python/collection/linux/enum_firewall.py
@@ -7,13 +7,13 @@ class Module:
         # metadata info about the module, not modified during runtime
         self.info = {
             # name for the module that will appear in module menus
-            'Name': 'Linux Hashdump',
+            'Name': 'Linux Enum IPTABLES',
 
             # list of one or more authors for the module
-            'Author': ['@harmj0y'],
+            'Author': ['@bneg'],
 
             # more verbose multi-line description of the module
-            'Description': ("Extracts the /etc/passwd and /etc/shadow, unshadowing the result."),
+            'Description': ("Print the active IPTABLES rules"),
 
             # True if the module needs to run in the background
             'Background' : False,
@@ -34,7 +34,7 @@ class Module:
             'MinLanguageVersion' : '2.6',
 
             # list of any references/other comments
-            'Comments': []
+            'Comments': ['Executes iptables -S on the host']
         }
 
         # any options needed by the module, settable during runtime


### PR DESCRIPTION
Fixed small typo in changelog
Added enum_firewall module for Linux in:
`Empire/lib/modules/python/collection/linux/enum_firewall.py`

Executes `iptables -S` and returns results