### PR TITLE
Quotation Type Bug

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -72,7 +72,7 @@ function Invoke-Empire {
         $WorkingHours,
 
         [String]
-        $Profile = '/admin/get.php,/news.php,/login/process.php|Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko',
+        $Profile = "/admin/get.php,/news.php,/login/process.php|Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
 
         [Int32]
         $LostLimit = 60,


### PR DESCRIPTION
Fixed a bug due to the type of quotations used. The code used in the generate_agent function of lib/listeners/http.py incorrectly matched the $Profile variable in data/agent/agent.ps1. This caused the generated agent not to be updated with the Empire listener's DefaultProfile values before being sent to the client. Changed the quotations in agent.ps1 to match the quotation in the generate_agent function's code where `code = code.replace('$Profile = "/admin/get.php,/news.php,/login/process.php|Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko"', "$Profile = \"" + str(profile) + "\"")`