### PR TITLE
Correctly handle all returns from Decode-Packet, fixes #413

### DIFF
--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -991,6 +991,7 @@ function Invoke-Empire {
             $TaskID = $Decoded[3]
             $Length = $Decoded[4]
             $Data = $Decoded[5]
+            $Remaining = $Decoded[6]
 
             # process the new sub-packet and add it to the result set
             $ResultPackets += $(Process-Tasking $Type $Data $TaskID)


### PR DESCRIPTION
Decode-Packet returns a dictionary of 7 variables but only 6 of which are currently handled in Process-TaskingPackets. The 7th variable is used as the control for the while loop (`while($Remaining.Length -ne 0) `) and therefore never changes, causing an infinite loop which results in the agent consuming all available CPU.

This edge case is only hit when there is more than a single task queued up as the first task is handled before entering the loop and that code correctly processes the entire return of Decode-Packet.