### PR TITLE
Expose the ForceASLR flag as a configuration option for code_executio…

### DIFF
--- a/lib/modules/powershell/code_execution/invoke_reflectivepeinjection.py
+++ b/lib/modules/powershell/code_execution/invoke_reflectivepeinjection.py
@@ -60,6 +60,11 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   ''
             },
+            'ForceASLR' : {
+                'Description'   :   'Optional, will force the use of ASLR on the PE being loaded even if the PE indicates it doesn\'t support ASLR.',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
             'ComputerName' : {
                 'Description'   :   'Optional an array of computernames to run the script on.',
                 'Required'      :   False,
@@ -110,7 +115,8 @@ class Module:
 
                         except:
                             print helpers.color("[!] Error in reading/encoding dll: " + str(values['Value']))
-
+                elif option.lower() == "forceaslr" and values['Value'].lower() == 'true':
+                    script += " -ForceASLR"
                 elif values['Value'] and values['Value'] != '':
                     script += " -" + str(option) + " " + str(values['Value'])
 


### PR DESCRIPTION
…n/invoke_reflectivepeinjection, fixes #415

The [original PowerSploit/Invoke-ReflectivePEInjection.ps1](https://github.com/PowerShellMafia/PowerSploit/blob/master/CodeExecution/Invoke-ReflectivePEInjection.ps1) has an optional argument -ForceASLR which is described as:

> Optional, will force the use of ASLR on the PE being loaded even if the PE indicates it doesn't support ASLR. Some PE's will work with ASLR even if the compiler flags don't indicate they support it. Other PE's will simply crash. Make sure to test this prior to using. Has no effect when loading in to a remote process.

This is notable as if you use msfvenom to generate a stageless meterpreter executable, it does not provide headers to describe the binary as supporting ASLR. This causes invoke_reflectivepeinjection to fail when injecting these payloads as evidenced in issue #415.

This PR exposes that argument to the Empire module allowing users to optionally enable it -- the default continues to omit the argument.